### PR TITLE
Fix payments mix up due to wrong selection of AMS TILL number - SER-3089

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## Version 1.3.1
 
         * [SER-2964] - Set up and Capture Logs on the MPESA Connecter to check on mix up of payments between PAYGOPS and ERPLY
+        * [SER-3089] - Fix payments mix up in the mpesa connector due to wrong selection of AMS TILL number
 
 ## Version 1.3.0
 

--- a/src/main/java/org/mifos/connector/mpesa/camel/routes/SafaricomRoutesBuilder.java
+++ b/src/main/java/org/mifos/connector/mpesa/camel/routes/SafaricomRoutesBuilder.java
@@ -333,9 +333,11 @@ public class SafaricomRoutesBuilder extends RouteBuilder {
                 .setHeader("Content-Type", constant("application/json"))
                 .setHeader("Authorization", simple("Bearer ${exchangeProperty."+ACCESS_TOKEN+"}"))
                 .setBody(exchange -> {
-                    mpesaProps = mpesaUtils.setMpesaProperties();
+                    String ams = exchange.getProperty(AMS, String.class);
+                    String transactionId = exchange.getProperty(CORRELATION_ID, String.class);
+                    mpesaProps = mpesaUtils.getMpesaProperties(ams, transactionId);
                     logger.info("MPESA properties for transaction with id {}: AMS - {}, Shortcode - {}, TILL - {}",
-                        exchange.getProperty(CORRELATION_ID), mpesaProps.getName(), mpesaProps.getBusinessShortCode(), mpesaProps.getTill());
+                        transactionId, mpesaProps.getName(), mpesaProps.getBusinessShortCode(), mpesaProps.getTill());
                     exchange.setProperty(PARTY_LOOKUP_FSP_ID, mpesaProps.getTill());
                     BuyGoodsPaymentRequestDTO buyGoodsPaymentRequestDTO =
                             (BuyGoodsPaymentRequestDTO) exchange.getProperty(BUY_GOODS_REQUEST_BODY);
@@ -347,7 +349,7 @@ public class SafaricomRoutesBuilder extends RouteBuilder {
                     buyGoodsPaymentRequestDTO.setPassword(password);
                     buyGoodsPaymentRequestDTO.setTransactionType(MPESA_BUY_GOODS_TRANSACTION_TYPE);
 
-                    logger.info("Buy goods request body for transaction with id {} on {}: \n\n..\n\n..\n\n.. {}", exchange.getProperty(CORRELATION_ID),
+                    logger.info("Buy goods request body for transaction with id {} on {}: \n\n..\n\n..\n\n.. {}", transactionId,
                         Instant.now(), buyGoodsPaymentRequestDTO);
                     logger.info(MpesaUtils.maskString(accessTokenStore.getAccessToken()));
 

--- a/src/main/java/org/mifos/connector/mpesa/flowcomponents/state/TransactionStateWorker.java
+++ b/src/main/java/org/mifos/connector/mpesa/flowcomponents/state/TransactionStateWorker.java
@@ -57,6 +57,7 @@ public class TransactionStateWorker {
 
                     Map<String, Object> variables = job.getVariablesAsMap();
                     String transactionId = (String) variables.get(TRANSACTION_ID);
+                    String ams = (String) variables.get(AMS);
                     if(skipMpesa){
                         logger.info("Skipping MPESA for transaction with id {}", transactionId);
                         Exchange exchange = new DefaultExchange(camelContext);
@@ -83,7 +84,7 @@ public class TransactionStateWorker {
                         TransactionChannelC2BRequestDTO channelRequest = objectMapper.readValue(
                                 (String) variables.get("mpesaChannelRequest"), TransactionChannelC2BRequestDTO.class);
                         BuyGoodsPaymentRequestDTO buyGoodsPaymentRequestDTO = safaricomUtils.channelRequestConvertor(
-                                channelRequest);
+                                channelRequest, transactionId, ams);
                         Exchange exchange = new DefaultExchange(camelContext);
                         exchange.setProperty(CORRELATION_ID, variables.get("transactionId"));
                         exchange.setProperty(TRANSACTION_ID, variables.get("transactionId"));

--- a/src/main/java/org/mifos/connector/mpesa/flowcomponents/transaction/MpesaWorker.java
+++ b/src/main/java/org/mifos/connector/mpesa/flowcomponents/transaction/MpesaWorker.java
@@ -84,10 +84,8 @@ public class MpesaWorker {
                     logger.info("Time diff " + (t2 - t1));
 
                     Map<String, Object> variables = job.getVariablesAsMap();
+                    mpesaUtils.setProcess(job.getBpmnProcessId());
                     String transactionId = (String) variables.get(TRANSACTION_ID);
-                    mpesaUtils.setProcess(job.getBpmnProcessId(), transactionId);
-                    String processAMS = (String) variables.get(AMS);
-                    mpesaUtils.setProcessAMS(processAMS, transactionId);
                     if (skipMpesa) {
                         logger.info("Skipping MPESA for transaction with id {}", transactionId);
                         Exchange exchange = new DefaultExchange(camelContext);
@@ -98,14 +96,15 @@ public class MpesaWorker {
                     } else {
                         TransactionChannelC2BRequestDTO channelRequest = objectMapper.readValue(
                                 (String) variables.get("mpesaChannelRequest"), TransactionChannelC2BRequestDTO.class);
-
+                        String ams = (String) variables.get(AMS);
                         BuyGoodsPaymentRequestDTO buyGoodsPaymentRequestDTO = safaricomUtils.channelRequestConvertor(
-                                channelRequest);
+                                channelRequest, transactionId, ams);
                         logger.info(buyGoodsPaymentRequestDTO.toString());
                         Exchange exchange = new DefaultExchange(camelContext);
                         exchange.setProperty(BUY_GOODS_REQUEST_BODY, buyGoodsPaymentRequestDTO);
                         exchange.setProperty(CORRELATION_ID, transactionId);
                         exchange.setProperty(DEPLOYED_PROCESS, job.getBpmnProcessId());
+                        exchange.setProperty(AMS, ams);
 
                         variables.put(BUY_GOODS_REQUEST_BODY, buyGoodsPaymentRequestDTO.toString());
 

--- a/src/main/java/org/mifos/connector/mpesa/utility/MpesaUtils.java
+++ b/src/main/java/org/mifos/connector/mpesa/utility/MpesaUtils.java
@@ -49,9 +49,6 @@ public class MpesaUtils {
     @Value("${fineract.host}")
     private String fineractHost;
 
-    private String processAMS;
-    private String processTxnId;
-
     enum ams {
         paygops,
         roster,
@@ -265,16 +262,11 @@ public class MpesaUtils {
                 }
             }
         }
-        if (properties != null && !properties.getName().equals(this.processAMS)) {
-            logger.error("MPESA properties mismatch for transaction {}. Selected AMS is {} while the process AMS is {}. Groups are {}",
-                this.processTxnId, properties.getName(), this.processAMS, groups);
-        }
         return properties;
     }
 
-    public void setProcess(String process, String transactionId) {
+    public void setProcess(String process) {
         this.process = process;
-        logger.info("Process {} set for transaction {}", this.process, transactionId);
     }
 
     public static String maskString(String strText) {
@@ -306,10 +298,32 @@ public class MpesaUtils {
         System.out.println(maskString(dt));
     }
 
-    public void setProcessAMS(String processAMS, String transactionId) {
-        this.processAMS = processAMS;
-        this.processTxnId = transactionId;
-        logger.info("ProcessAMS {} set for transaction {}. Process is {}", this.processAMS, this.processTxnId, this.process);
+    /**
+     * Get the MPESA properties for the given AMS
+     * @param ams the AMS name
+     * @param transactionId the ID of the current transaction
+     * @return the MPESA properties for the given AMS
+     */
+    public MpesaProps.MPESA getMpesaProperties(String ams, String transactionId) {
+        MpesaProps.MPESA properties = null;
+        List<MpesaProps.MPESA> groups = getGroup();
+        for (MpesaProps.MPESA identifier : groups) {
+            String name = identifier.getName();
+            if (name.equalsIgnoreCase(ams)) {
+                properties = identifier;
+                break;
+
+            } else {
+                if (name.equals("default")) {
+                    properties = identifier;
+                }
+            }
+        }
+        if (properties != null && !properties.getName().equalsIgnoreCase(ams)) {
+            logger.warn("MPESA properties mismatch for transaction {}. Selected AMS is {} while the process AMS is {}. Groups are {}",
+                transactionId, properties.getName(), ams, groups);
+        }
+        return properties;
     }
 
 }

--- a/src/main/java/org/mifos/connector/mpesa/utility/SafaricomUtils.java
+++ b/src/main/java/org/mifos/connector/mpesa/utility/SafaricomUtils.java
@@ -41,10 +41,10 @@ public class SafaricomUtils {
     private final SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMddHHmmss");
 
 
-    public BuyGoodsPaymentRequestDTO channelRequestConvertor(TransactionChannelC2BRequestDTO transactionChannelRequestDTO) {
+    public BuyGoodsPaymentRequestDTO channelRequestConvertor(TransactionChannelC2BRequestDTO transactionChannelRequestDTO, String transactionId, String ams) {
         logger.info("TransactionChannelCollectionRequestDTO chile converting " + transactionChannelRequestDTO);
         BuyGoodsPaymentRequestDTO buyGoodsPaymentRequestDTO = new BuyGoodsPaymentRequestDTO();
-        mpesaProps = mpesaUtils.setMpesaProperties();
+        mpesaProps = mpesaUtils.getMpesaProperties(ams, transactionId);
 
         long amount = Long.parseLong(transactionChannelRequestDTO.getAmount().getAmount().trim());
         long timestamp = getTimestamp(); //123; //Long.parseLong(sdf.format(new Date()));


### PR DESCRIPTION
## Description

The class (MpesaUtils) that holds the mpesa properties is annotated with Spring's `@Component `which makes the class a singleton by default. This means the same instance will be shared by all threads in the application. In situations where a payment processed in one thread does not complete quickly, and is being overtaken by another thread's payment (for a different AMS), the mpesa properties which were initially set by the first thread will be overwritten by the second thread, causing the first payment to then use an incorrect AMS TILL number.

This PR addresses the issue by ensuring an AMS argument is passed to the method that retrieves the mpesa properties for each payment.
