### PR TITLE
fix: FD-1882 make Zeebe timebound configurable and fail jobs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Version 1.3.7
+
+        * [FD-1882] - Add a timeout and keep alive  on zeebe to resolve job workers becoming stuck
+
 ## Version 1.3.6.1
 
         * [CP-3931] - Use Kenya as the accountHoldingInstitution for multitenancy

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 ## Version 1.3.7
 
-        * [FD-1882] - Add a timeout and keep alive  on zeebe to resolve job workers becoming stuck
+        * [FD-1882] - Add a timeout and keep-alive on Zeebe to resolve job workers becoming stuck
 
 ## Version 1.3.6.1
 

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ dependencies {
 
 
 group = 'org.mifos'
-version = '1.3.6.1'
+version = '1.3.7'
 
 java {
     toolchain {

--- a/src/main/java/org/mifos/connector/mpesa/camel/routes/OperationsRouteBuilder.java
+++ b/src/main/java/org/mifos/connector/mpesa/camel/routes/OperationsRouteBuilder.java
@@ -3,7 +3,9 @@ package org.mifos.connector.mpesa.camel.routes;
 import io.camunda.zeebe.client.ZeebeClient;
 import org.apache.camel.LoggingLevel;
 import org.json.JSONObject;
+import org.mifos.connector.mpesa.zeebe.ZeebeCommandHelper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.mifos.connector.common.camel.ErrorHandlerRouteBuilder;
 
@@ -20,6 +22,9 @@ public class OperationsRouteBuilder extends ErrorHandlerRouteBuilder {
     @Autowired
     private ZeebeClient zeebeClient;
 
+    @Value("${zeebe.client.request-timeout}")
+    private Duration requestTimeout;
+
     @Override
     public void configure() {
 
@@ -33,13 +38,12 @@ public class OperationsRouteBuilder extends ErrorHandlerRouteBuilder {
                         variables.put(k, request.get(k));
                     });
 
-                    zeebeClient.newPublishMessageCommand()
+                    ZeebeCommandHelper.join(zeebeClient.newPublishMessageCommand()
                             .messageName(OPERATOR_MANUAL_RECOVERY)
                             .correlationKey(e.getIn().getHeader(TRANSACTION_ID, String.class))
                             .timeToLive(Duration.ofMillis(30000))
                             .variables(variables)
-                            .send()
-                            .join();
+                            .send(), requestTimeout);
                 })
                 .setBody(constant((Object) null));
 
@@ -55,19 +59,16 @@ public class OperationsRouteBuilder extends ErrorHandlerRouteBuilder {
                         newVariables.put(k, requestedVariables.get(k));
                     });
 
-                    zeebeClient.newSetVariablesCommand(incident.getLong("elementInstanceKey"))
+                    ZeebeCommandHelper.join(zeebeClient.newSetVariablesCommand(incident.getLong("elementInstanceKey"))
                             .variables(newVariables)
-                            .send()
-                            .join();
+                            .send(), requestTimeout);
 
-                    zeebeClient.newUpdateRetriesCommand(incident.getLong("jobKey"))
+                    ZeebeCommandHelper.join(zeebeClient.newUpdateRetriesCommand(incident.getLong("jobKey"))
                             .retries(incident.getInt("newRetries"))
-                            .send()
-                            .join();
+                            .send(), requestTimeout);
 
-                    zeebeClient.newResolveIncidentCommand(incident.getLong("key"))
-                            .send()
-                            .join();
+                    ZeebeCommandHelper.join(zeebeClient.newResolveIncidentCommand(incident.getLong("key"))
+                            .send(), requestTimeout);
                 })
                 .setBody(constant((Object) null));
 
@@ -83,23 +84,22 @@ public class OperationsRouteBuilder extends ErrorHandlerRouteBuilder {
                         newVariables.put(k, requestedVariables.get(k));
                     });
 
-                    zeebeClient.newSetVariablesCommand(incident.getLong("elementInstanceKey"))
+                    ZeebeCommandHelper.join(zeebeClient.newSetVariablesCommand(incident.getLong("elementInstanceKey"))
                             .variables(newVariables)
-                            .send()
-                            .join();
+                            .send(), requestTimeout);
 
-                    zeebeClient.newResolveIncidentCommand(incident.getLong("key"))
-                            .send()
-                            .join();
+                    ZeebeCommandHelper.join(zeebeClient.newResolveIncidentCommand(incident.getLong("key"))
+                            .send(), requestTimeout);
                 })
                 .setBody(constant((Object) null));
 
         from("rest:POST:/channel/workflow/{workflowInstanceKey}/cancel")
                 .id("workflow-cancel")
                 .log(LoggingLevel.INFO, "## operator workflow cancel ${header.workflowInstanceKey}")
-                .process(e -> zeebeClient.newCancelInstanceCommand(Long.parseLong(e.getIn().getHeader("workflowInstanceKey", String.class)))
-                        .send()
-                        .join())
+                .process(e -> ZeebeCommandHelper.join(
+                        zeebeClient.newCancelInstanceCommand(
+                                        Long.parseLong(e.getIn().getHeader("workflowInstanceKey", String.class)))
+                                .send(), requestTimeout))
                 .setBody(constant((Object) null));
 
     }

--- a/src/main/java/org/mifos/connector/mpesa/flowcomponents/state/TransactionStateWorker.java
+++ b/src/main/java/org/mifos/connector/mpesa/flowcomponents/state/TransactionStateWorker.java
@@ -9,6 +9,7 @@ import org.apache.camel.support.DefaultExchange;
 import org.mifos.connector.common.channel.dto.TransactionChannelC2BRequestDTO;
 import org.mifos.connector.mpesa.dto.BuyGoodsPaymentRequestDTO;
 import org.mifos.connector.mpesa.utility.SafaricomUtils;
+import org.mifos.connector.mpesa.zeebe.ZeebeCommandHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,6 +48,9 @@ public class TransactionStateWorker {
     @Value("${skip.enabled}")
     private Boolean skipMpesa;
 
+    @Value("${zeebe.client.request-timeout}")
+    private Duration requestTimeout;
+
     @PostConstruct
     public void setupWorkers() {
 
@@ -68,14 +72,20 @@ public class TransactionStateWorker {
                         variables.put(SERVER_TRANSACTION_STATUS_RETRY_COUNT, retryCount);
                         variables.put(SERVER_TRANSACTION_ID, serverTransactionId);
                         exchange.setProperty(TIMER, variables.get(TIMER));
-                        zeebeClient.newPublishMessageCommand()
-                                .messageName(TRANSFER_MESSAGE)
-                                .correlationKey((String) variables.get("transactionId"))
-                                .timeToLive(Duration.ofMillis(300))
-                                .variables(variables)
-                                .send()
-                                .join();
-                        logger.info("Published Variables");
+                        try {
+                            ZeebeCommandHelper.join(zeebeClient.newPublishMessageCommand()
+                                    .messageName(TRANSFER_MESSAGE)
+                                    .correlationKey((String) variables.get("transactionId"))
+                                    .timeToLive(Duration.ofMillis(300))
+                                    .variables(variables)
+                                    .send(), requestTimeout);
+                            logger.info("Published Variables");
+                        } catch (Exception e) {
+                            logger.error("Publish message failed for job {}", job.getKey(), e);
+                            ZeebeCommandHelper.failJob(client, job,
+                                    "Publish message failed: " + e.getMessage(), requestTimeout, logger);
+                            return;
+                        }
                     }
                     else {
                         Integer retryCount = 1 + (Integer) variables.getOrDefault(SERVER_TRANSACTION_STATUS_RETRY_COUNT, 0);
@@ -96,15 +106,9 @@ public class TransactionStateWorker {
                         exchange.setProperty(DEPLOYED_PROCESS, job.getBpmnProcessId());
 
                         producerTemplate.send("direct:get-transaction-status-base", exchange);
+                    }
 
-                    /*variables.put(STATUS_AVAILABLE, exchange.getProperty(STATUS_AVAILABLE, Boolean.class));
-                    if (exchange.getProperty(STATUS_AVAILABLE, Boolean.class)) {
-                        variables.put(TRANSACTION_STATUS, exchange.getProperty(TRANSACTION_STATUS, String.class));
-                    }*/}
-
-                        client.newCompleteCommand(job.getKey())
-                                .send()
-                                .join();
+                    ZeebeCommandHelper.completeJob(client, job, null, requestTimeout, logger);
                     })
                 .name("get-transaction-status")
                 .maxJobsActive(workerMaxJobs)

--- a/src/main/java/org/mifos/connector/mpesa/flowcomponents/transaction/CollectionResponseProcessor.java
+++ b/src/main/java/org/mifos/connector/mpesa/flowcomponents/transaction/CollectionResponseProcessor.java
@@ -7,6 +7,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.http.base.HttpOperationFailedException;
 import org.apache.camel.util.json.JsonObject;
 import org.mifos.connector.mpesa.utility.ZeebeUtils;
+import org.mifos.connector.mpesa.zeebe.ZeebeCommandHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,6 +34,9 @@ public class CollectionResponseProcessor implements Processor {
 
     @Value("${zeebe.client.ttl}")
     private int timeToLive;
+
+    @Value("${zeebe.client.request-timeout}")
+    private Duration requestTimeout;
 
     public CollectionResponseProcessor(ZeebeClient zeebeClient) {
         this.zeebeClient = zeebeClient;
@@ -74,10 +78,9 @@ public class CollectionResponseProcessor implements Processor {
             logger.info("Updating timer value to " + newTimer);
             variables.put(TIMER, newTimer);
             Long elementInstanceKey = (Long) exchange.getProperty(ZEEBE_ELEMENT_INSTANCE_KEY);
-            zeebeClient.newSetVariablesCommand(elementInstanceKey)
+            ZeebeCommandHelper.join(zeebeClient.newSetVariablesCommand(elementInstanceKey)
                     .variables(variables)
-                    .send()
-                    .join();
+                    .send(), requestTimeout);
             return;
         }
 
@@ -122,12 +125,11 @@ public class CollectionResponseProcessor implements Processor {
             return;
         }
         logger.info("Publishing transaction message variables: " + variables);
-        zeebeClient.newPublishMessageCommand()
+        ZeebeCommandHelper.join(zeebeClient.newPublishMessageCommand()
                 .messageName(TRANSFER_MESSAGE)
                 .correlationKey(clientCorrelationId)
                 .timeToLive(Duration.ofMillis(timeToLive))
                 .variables(variables)
-                .send()
-                .join();
+                .send(), requestTimeout);
     }
 }

--- a/src/main/java/org/mifos/connector/mpesa/flowcomponents/transaction/MpesaWorker.java
+++ b/src/main/java/org/mifos/connector/mpesa/flowcomponents/transaction/MpesaWorker.java
@@ -11,6 +11,7 @@ import org.mifos.connector.mpesa.dto.BuyGoodsPaymentRequestDTO;
 import org.mifos.connector.mpesa.utility.MpesaUtils;
 import org.mifos.connector.mpesa.utility.SafaricomUtils;
 import org.mifos.connector.mpesa.utility.ZeebeUtils;
+import org.mifos.connector.mpesa.zeebe.ZeebeCommandHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,6 +19,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -68,6 +70,9 @@ public class MpesaWorker {
 
     @Value("${skip.enabled}")
     private Boolean skipMpesa;
+
+    @Value("${zeebe.client.request-timeout}")
+    private Duration requestTimeout;
 
     @PostConstruct
     public void setupWorkers() {
@@ -130,10 +135,7 @@ public class MpesaWorker {
                         }
                     }
 
-                    client.newCompleteCommand(job.getKey())
-                            .variables(variables)
-                            .send()
-                            .join();
+                    ZeebeCommandHelper.completeJob(client, job, variables, requestTimeout, logger);
                 })
                 .name("init-transfer")
                 .maxJobsActive(workerMaxJobs)
@@ -149,10 +151,7 @@ public class MpesaWorker {
                     workflowInstanceStore.remove(mpesaTxnId);
                     Map<String, Object> completionVariables = new HashMap<>();
                     completionVariables.put(TRANSFER_CREATE_FAILED, true);
-                    client.newCompleteCommand(job.getKey())
-                            .variables(completionVariables)
-                            .send()
-                            .join();
+                    ZeebeCommandHelper.completeJob(client, job, completionVariables, requestTimeout, logger);
                 }))
                 .name("Cleanup")
                 .maxJobsActive(workerMaxJobs)

--- a/src/main/java/org/mifos/connector/mpesa/zeebe/ZeebeClientConfiguration.java
+++ b/src/main/java/org/mifos/connector/mpesa/zeebe/ZeebeClientConfiguration.java
@@ -5,6 +5,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.time.Duration;
+
 @Configuration
 public class ZeebeClientConfiguration {
 
@@ -14,12 +16,20 @@ public class ZeebeClientConfiguration {
     @Value("${zeebe.client.max-execution-threads}")
     private int zeebeClientMaxThreads;
 
+    @Value("${zeebe.client.keep-alive}")
+    private Duration keepAlive;
+
+    @Value("${zeebe.client.request-timeout}")
+    private Duration requestTimeout;
+
     @Bean
     public ZeebeClient setup() {
         return ZeebeClient.newClientBuilder()
                 .gatewayAddress(zeebeBrokerContactpoint)
                 .usePlaintext()
                 .numJobWorkerExecutionThreads(zeebeClientMaxThreads)
+                .keepAlive(keepAlive)
+                .defaultRequestTimeout(requestTimeout)
                 .build();
     }
 }

--- a/src/main/java/org/mifos/connector/mpesa/zeebe/ZeebeCommandHelper.java
+++ b/src/main/java/org/mifos/connector/mpesa/zeebe/ZeebeCommandHelper.java
@@ -1,0 +1,79 @@
+package org.mifos.connector.mpesa.zeebe;
+
+import io.camunda.zeebe.client.api.ZeebeFuture;
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.client.api.worker.JobClient;
+import org.slf4j.Logger;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Helpers to keep Zeebe command waits bounded so worker {@code maxJobsActive} slots
+ * cannot be held forever on a half-open gRPC channel.
+ */
+public final class ZeebeCommandHelper {
+
+    private ZeebeCommandHelper() {
+    }
+
+    public static <T> T join(ZeebeFuture<T> future, Duration timeout) {
+        try {
+            return future.join(timeout.toMillis(), TimeUnit.MILLISECONDS);
+        } catch (RuntimeException e) {
+            restoreInterruptStatus(e);
+            throw e;
+        }
+    }
+
+    /**
+     * Completes a job with a bounded wait. On timeout/failure, attempts a bounded fail
+     * so the job can be retried. Does not rethrow — returning frees the local worker slot
+     * even if the broker ack never arrives (broker job timeout will re-offer).
+     */
+    public static void completeJob(JobClient client, ActivatedJob job, Map<String, Object> variables,
+                                   Duration timeout, Logger logger) {
+        try {
+            if (variables != null) {
+                join(client.newCompleteCommand(job.getKey()).variables(variables).send(), timeout);
+            } else {
+                join(client.newCompleteCommand(job.getKey()).send(), timeout);
+            }
+        } catch (Exception e) {
+            restoreInterruptStatus(e);
+            logger.error("Complete command failed for job {}; attempting fail for retry", job.getKey(), e);
+            failJob(client, job, "Complete command failed: " + e.getMessage(), timeout, logger);
+        }
+    }
+
+    public static void failJob(JobClient client, ActivatedJob job, String errorMessage,
+                               Duration timeout, Logger logger) {
+        try {
+            join(client.newFailCommand(job.getKey())
+                    .retries(Math.max(job.getRetries() - 1, 0))
+                    .errorMessage(errorMessage)
+                    .send(), timeout);
+        } catch (Exception e) {
+            restoreInterruptStatus(e);
+            logger.error(
+                    "Fail command also failed for job {}; releasing worker slot without broker ack",
+                    job.getKey(), e);
+        }
+    }
+
+    private static void restoreInterruptStatus(Throwable throwable) {
+        if (isInterrupted(throwable)) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static boolean isInterrupted(Throwable throwable) {
+        for (Throwable t = throwable; t != null; t = t.getCause()) {
+            if (t instanceof InterruptedException) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/org/mifos/connector/mpesa/zeebe/ZeebeProcessStarter.java
+++ b/src/main/java/org/mifos/connector/mpesa/zeebe/ZeebeProcessStarter.java
@@ -5,8 +5,10 @@ import org.apache.camel.Exchange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -19,6 +21,9 @@ public class ZeebeProcessStarter {
 
     @Autowired
     private ZeebeClient zeebeClient;
+
+    @Value("${zeebe.client.request-timeout}")
+    private Duration requestTimeout;
 
     public static void zeebeVariablesToCamelHeaders(Map<String, Object> variables, Exchange exchange, String... names) {
         for (String name : names) {
@@ -45,12 +50,11 @@ public class ZeebeProcessStarter {
         variables.putAll(extraVariables);
         // TODO: Add extra variables if required. Such as origin date.
 
-        zeebeClient.newCreateInstanceCommand()
+        ZeebeCommandHelper.join(zeebeClient.newCreateInstanceCommand()
                 .bpmnProcessId(workflowId)
                 .latestVersion() // .version(1)
                 .variables(variables)
-                .send()
-                .join();
+                .send(), requestTimeout);
 
         logger.info("zeebee workflow instance from process {} started", workflowId);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,10 @@ zeebe:
     number-of-workers: 5
     evenly-allocated-max-jobs: "#{${zeebe.client.max-execution-threads} / ${zeebe.client.number-of-workers}}"
     ttl: 30000
+    # Detect half-open gRPC connections (LB/NAT idle drops) so ActivateJobs can reconnect
+    keep-alive: 30s
+    # Bound all command futures (.join) so worker slots cannot hang forever
+    request-timeout: 30s
   broker:
     contactpoint: "localhost:26500"
   init-transfer:

--- a/src/test/java/org/mifos/connector/mpesa/zeebe/ZeebeClientConfigurationTest.java
+++ b/src/test/java/org/mifos/connector/mpesa/zeebe/ZeebeClientConfigurationTest.java
@@ -1,0 +1,30 @@
+package org.mifos.connector.mpesa.zeebe;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class ZeebeClientConfigurationTest {
+
+    @Test
+    void setup_buildsClientWithConfiguredKeepAliveAndRequestTimeout() {
+        ZeebeClientConfiguration configuration = new ZeebeClientConfiguration();
+        ReflectionTestUtils.setField(configuration, "zeebeBrokerContactpoint", "localhost:26500");
+        ReflectionTestUtils.setField(configuration, "zeebeClientMaxThreads", 10);
+        ReflectionTestUtils.setField(configuration, "keepAlive", Duration.ofSeconds(30));
+        ReflectionTestUtils.setField(configuration, "requestTimeout", Duration.ofSeconds(30));
+
+        try (ZeebeClient client = configuration.setup()) {
+            assertNotNull(client);
+            assertEquals(Duration.ofSeconds(30), client.getConfiguration().getKeepAlive());
+            assertEquals(Duration.ofSeconds(30), client.getConfiguration().getDefaultRequestTimeout());
+            assertEquals(10, client.getConfiguration().getNumJobWorkerExecutionThreads());
+            assertEquals("localhost:26500", client.getConfiguration().getGatewayAddress());
+        }
+    }
+}

--- a/src/test/java/org/mifos/connector/mpesa/zeebe/ZeebeCommandHelperTest.java
+++ b/src/test/java/org/mifos/connector/mpesa/zeebe/ZeebeCommandHelperTest.java
@@ -1,0 +1,274 @@
+package org.mifos.connector.mpesa.zeebe;
+
+import io.camunda.zeebe.client.api.ZeebeFuture;
+import io.camunda.zeebe.client.api.command.ClientException;
+import io.camunda.zeebe.client.api.command.CompleteJobCommandStep1;
+import io.camunda.zeebe.client.api.command.FailJobCommandStep1;
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.client.api.response.CompleteJobResponse;
+import io.camunda.zeebe.client.api.response.FailJobResponse;
+import io.camunda.zeebe.client.api.worker.JobClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ZeebeCommandHelperTest {
+
+    private static final Duration TIMEOUT = Duration.ofSeconds(30);
+    private static final long JOB_KEY = 42L;
+    private static final Logger LOGGER = LoggerFactory.getLogger(ZeebeCommandHelperTest.class);
+
+    @Mock
+    private JobClient jobClient;
+
+    @Mock
+    private ActivatedJob job;
+
+    @Mock
+    private CompleteJobCommandStep1 completeCommand;
+
+    @Mock
+    private FailJobCommandStep1 failCommandStep1;
+
+    @Mock
+    private FailJobCommandStep1.FailJobCommandStep2 failCommandStep2;
+
+    @AfterEach
+    void clearInterruptFlag() {
+        Thread.interrupted();
+    }
+
+    @Test
+    void join_returnsFutureResult() {
+        @SuppressWarnings("unchecked")
+        ZeebeFuture<String> future = mock(ZeebeFuture.class);
+        when(future.join(eq(30_000L), eq(TimeUnit.MILLISECONDS))).thenReturn("ok");
+
+        assertEquals("ok", ZeebeCommandHelper.join(future, TIMEOUT));
+    }
+
+    @Test
+    void join_usesTimeoutMillis() {
+        @SuppressWarnings("unchecked")
+        ZeebeFuture<String> future = mock(ZeebeFuture.class);
+        when(future.join(anyLong(), eq(TimeUnit.MILLISECONDS))).thenReturn("ok");
+
+        ZeebeCommandHelper.join(future, Duration.ofSeconds(5));
+
+        verify(future).join(5_000L, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    void join_rethrowsRuntimeExceptionWithoutSettingInterrupt() {
+        @SuppressWarnings("unchecked")
+        ZeebeFuture<String> future = mock(ZeebeFuture.class);
+        when(future.join(anyLong(), eq(TimeUnit.MILLISECONDS)))
+                .thenThrow(new ClientException("timeout"));
+
+        assertThrows(ClientException.class, () -> ZeebeCommandHelper.join(future, TIMEOUT));
+        assertFalse(Thread.currentThread().isInterrupted());
+    }
+
+    @Test
+    void join_restoresInterruptWhenCauseIsInterruptedException() {
+        @SuppressWarnings("unchecked")
+        ZeebeFuture<String> future = mock(ZeebeFuture.class);
+        when(future.join(anyLong(), eq(TimeUnit.MILLISECONDS)))
+                .thenThrow(new ClientException("interrupted", new InterruptedException("stopped")));
+
+        assertThrows(ClientException.class, () -> ZeebeCommandHelper.join(future, TIMEOUT));
+        assertTrue(Thread.currentThread().isInterrupted());
+    }
+
+    @Test
+    void completeJob_withVariables_sendsCompleteCommand() {
+        when(job.getKey()).thenReturn(JOB_KEY);
+        @SuppressWarnings("unchecked")
+        ZeebeFuture<CompleteJobResponse> future = mock(ZeebeFuture.class);
+        when(jobClient.newCompleteCommand(JOB_KEY)).thenReturn(completeCommand);
+        when(completeCommand.variables(anyMap())).thenReturn(completeCommand);
+        when(completeCommand.send()).thenReturn(future);
+        when(future.join(anyLong(), eq(TimeUnit.MILLISECONDS))).thenReturn(mock(CompleteJobResponse.class));
+
+        Map<String, Object> variables = Map.of("transactionFailed", false);
+        ZeebeCommandHelper.completeJob(jobClient, job, variables, TIMEOUT, LOGGER);
+
+        verify(completeCommand).variables(variables);
+        verify(completeCommand).send();
+        verify(future).join(30_000L, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    void completeJob_withNullVariables_sendsCompleteWithoutVariables() {
+        when(job.getKey()).thenReturn(JOB_KEY);
+        @SuppressWarnings("unchecked")
+        ZeebeFuture<CompleteJobResponse> future = mock(ZeebeFuture.class);
+        when(jobClient.newCompleteCommand(JOB_KEY)).thenReturn(completeCommand);
+        when(completeCommand.send()).thenReturn(future);
+        when(future.join(anyLong(), eq(TimeUnit.MILLISECONDS))).thenReturn(mock(CompleteJobResponse.class));
+
+        ZeebeCommandHelper.completeJob(jobClient, job, null, TIMEOUT, LOGGER);
+
+        verify(completeCommand).send();
+        verify(future).join(30_000L, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    void completeJob_onFailure_attemptsFailWithDecrementedRetries() {
+        stubJobKeyAndRetries(3);
+        @SuppressWarnings("unchecked")
+        ZeebeFuture<CompleteJobResponse> completeFuture = mock(ZeebeFuture.class);
+        @SuppressWarnings("unchecked")
+        ZeebeFuture<FailJobResponse> failFuture = mock(ZeebeFuture.class);
+
+        when(jobClient.newCompleteCommand(JOB_KEY)).thenReturn(completeCommand);
+        when(completeCommand.send()).thenReturn(completeFuture);
+        when(completeFuture.join(anyLong(), eq(TimeUnit.MILLISECONDS)))
+                .thenThrow(new ClientException("complete timed out"));
+
+        when(jobClient.newFailCommand(JOB_KEY)).thenReturn(failCommandStep1);
+        when(failCommandStep1.retries(2)).thenReturn(failCommandStep2);
+        when(failCommandStep2.errorMessage(anyString())).thenReturn(failCommandStep2);
+        when(failCommandStep2.send()).thenReturn(failFuture);
+        when(failFuture.join(anyLong(), eq(TimeUnit.MILLISECONDS))).thenReturn(mock(FailJobResponse.class));
+
+        ZeebeCommandHelper.completeJob(jobClient, job, null, TIMEOUT, LOGGER);
+
+        ArgumentCaptor<String> errorCaptor = ArgumentCaptor.forClass(String.class);
+        verify(failCommandStep1).retries(2);
+        verify(failCommandStep2).errorMessage(errorCaptor.capture());
+        assertTrue(errorCaptor.getValue().contains("Complete command failed"));
+        verify(failFuture).join(30_000L, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    void completeJob_whenFailAlsoFails_doesNotThrow() {
+        stubJobKeyAndRetries(1);
+        @SuppressWarnings("unchecked")
+        ZeebeFuture<CompleteJobResponse> completeFuture = mock(ZeebeFuture.class);
+        @SuppressWarnings("unchecked")
+        ZeebeFuture<FailJobResponse> failFuture = mock(ZeebeFuture.class);
+
+        when(jobClient.newCompleteCommand(JOB_KEY)).thenReturn(completeCommand);
+        when(completeCommand.send()).thenReturn(completeFuture);
+        when(completeFuture.join(anyLong(), eq(TimeUnit.MILLISECONDS)))
+                .thenThrow(new ClientException("complete timed out"));
+
+        when(jobClient.newFailCommand(JOB_KEY)).thenReturn(failCommandStep1);
+        when(failCommandStep1.retries(0)).thenReturn(failCommandStep2);
+        when(failCommandStep2.errorMessage(anyString())).thenReturn(failCommandStep2);
+        when(failCommandStep2.send()).thenReturn(failFuture);
+        when(failFuture.join(anyLong(), eq(TimeUnit.MILLISECONDS)))
+                .thenThrow(new ClientException("fail timed out"));
+
+        ZeebeCommandHelper.completeJob(jobClient, job, null, TIMEOUT, LOGGER);
+
+        verify(failCommandStep1).retries(0);
+    }
+
+    @Test
+    void completeJob_onInterruptedFailure_restoresInterruptFlag() {
+        stubJobKeyAndRetries(2);
+        @SuppressWarnings("unchecked")
+        ZeebeFuture<CompleteJobResponse> completeFuture = mock(ZeebeFuture.class);
+        @SuppressWarnings("unchecked")
+        ZeebeFuture<FailJobResponse> failFuture = mock(ZeebeFuture.class);
+
+        when(jobClient.newCompleteCommand(JOB_KEY)).thenReturn(completeCommand);
+        when(completeCommand.send()).thenReturn(completeFuture);
+        when(completeFuture.join(anyLong(), eq(TimeUnit.MILLISECONDS)))
+                .thenThrow(new ClientException("interrupted", new InterruptedException("stopped")));
+
+        when(jobClient.newFailCommand(JOB_KEY)).thenReturn(failCommandStep1);
+        when(failCommandStep1.retries(anyInt())).thenReturn(failCommandStep2);
+        when(failCommandStep2.errorMessage(anyString())).thenReturn(failCommandStep2);
+        when(failCommandStep2.send()).thenReturn(failFuture);
+        when(failFuture.join(anyLong(), eq(TimeUnit.MILLISECONDS))).thenReturn(mock(FailJobResponse.class));
+
+        ZeebeCommandHelper.completeJob(jobClient, job, null, TIMEOUT, LOGGER);
+
+        assertTrue(Thread.currentThread().isInterrupted());
+    }
+
+    @Test
+    void failJob_sendsFailCommandWithBoundedJoin() {
+        stubJobKeyAndRetries(5);
+        @SuppressWarnings("unchecked")
+        ZeebeFuture<FailJobResponse> failFuture = mock(ZeebeFuture.class);
+
+        when(jobClient.newFailCommand(JOB_KEY)).thenReturn(failCommandStep1);
+        when(failCommandStep1.retries(4)).thenReturn(failCommandStep2);
+        when(failCommandStep2.errorMessage("boom")).thenReturn(failCommandStep2);
+        when(failCommandStep2.send()).thenReturn(failFuture);
+        when(failFuture.join(anyLong(), eq(TimeUnit.MILLISECONDS))).thenReturn(mock(FailJobResponse.class));
+
+        ZeebeCommandHelper.failJob(jobClient, job, "boom", TIMEOUT, LOGGER);
+
+        verify(failCommandStep1).retries(4);
+        verify(failCommandStep2).errorMessage("boom");
+        verify(failFuture).join(30_000L, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    void failJob_withZeroRetries_doesNotGoNegative() {
+        stubJobKeyAndRetries(0);
+        @SuppressWarnings("unchecked")
+        ZeebeFuture<FailJobResponse> failFuture = mock(ZeebeFuture.class);
+
+        when(jobClient.newFailCommand(JOB_KEY)).thenReturn(failCommandStep1);
+        when(failCommandStep1.retries(0)).thenReturn(failCommandStep2);
+        when(failCommandStep2.errorMessage(anyString())).thenReturn(failCommandStep2);
+        when(failCommandStep2.send()).thenReturn(failFuture);
+        when(failFuture.join(anyLong(), eq(TimeUnit.MILLISECONDS))).thenReturn(mock(FailJobResponse.class));
+
+        ZeebeCommandHelper.failJob(jobClient, job, "no retries left", TIMEOUT, LOGGER);
+
+        verify(failCommandStep1).retries(0);
+    }
+
+    @Test
+    void failJob_onInterruptedFailure_restoresInterruptFlagAndDoesNotThrow() {
+        stubJobKeyAndRetries(2);
+        @SuppressWarnings("unchecked")
+        ZeebeFuture<FailJobResponse> failFuture = mock(ZeebeFuture.class);
+
+        when(jobClient.newFailCommand(JOB_KEY)).thenReturn(failCommandStep1);
+        when(failCommandStep1.retries(anyInt())).thenReturn(failCommandStep2);
+        when(failCommandStep2.errorMessage(anyString())).thenReturn(failCommandStep2);
+        when(failCommandStep2.send()).thenReturn(failFuture);
+        when(failFuture.join(anyLong(), eq(TimeUnit.MILLISECONDS)))
+                .thenThrow(new ClientException("interrupted", new InterruptedException("stopped")));
+
+        ZeebeCommandHelper.failJob(jobClient, job, "boom", TIMEOUT, LOGGER);
+
+        assertTrue(Thread.currentThread().isInterrupted());
+    }
+
+    private void stubJobKeyAndRetries(int retries) {
+        when(job.getKey()).thenReturn(JOB_KEY);
+        when(job.getRetries()).thenReturn(retries);
+    }
+}


### PR DESCRIPTION
## Description

* Added timeout and keep alive on zeebe commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Zeebe keep-alive and request timeouts.
  * Improved job completion and failure handling, including safer retries when commands fail.
  * Prevented workflow and message operations from waiting indefinitely.

* **Bug Fixes**
  * Reduced the risk of job workers becoming stuck during Zeebe communication.
  * Added reconnect support for idle connection drops.

* **Tests**
  * Added coverage for timeout, interruption, connection configuration, and job failure behavior.

* **Release**
  * Updated the application version to 1.3.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->